### PR TITLE
Do not load HTTP on sites using HTTPS

### DIFF
--- a/cfwc-form.php
+++ b/cfwc-form.php
@@ -204,7 +204,7 @@ if(document.getElementById("recaptcha_response_field").value=="")
          <?php
             if ($publickey != null)
             {
-                echo recaptcha_get_html($publickey, $error);
+                echo recaptcha_get_html($publickey, $error, is_ssl());
             }
             else
             {


### PR DESCRIPTION
The plugin attempts to contact the API over HTTP regardless of what the host site is using. On a lot of browsers it's considered an insecure element and not shown, breaking the form.
